### PR TITLE
Fix operator precedence and sanitize $_GET in Elementor preview check

### DIFF
--- a/yayforms.php
+++ b/yayforms.php
@@ -209,7 +209,7 @@ function yayforms_shortcode($atts) {
     }
     wp_enqueue_script('yayforms-embed');
     
-    // Para Elementor preview, adicionar o script diretamente no HTML
+    // For Elementor preview, inject the script tag inline
     $is_elementor_preview = isset($_GET['elementor-preview'])
         || (isset($_GET['action']) && sanitize_text_field(wp_unslash($_GET['action'])) === 'elementor');
     if (is_admin() || $is_elementor_preview) {

--- a/yayforms.php
+++ b/yayforms.php
@@ -105,7 +105,6 @@ function yayforms_shortcode($atts) {
         'color' => '#000000',
     ), $atts);
 
-    // Verificar nonce apenas se estiver fazendo AJAX e tiver nonce disponível
     if (wp_doing_ajax() && isset($_REQUEST['yayforms_nonce'])) {
         if (!wp_verify_nonce(sanitize_text_field(wp_unslash($_REQUEST['yayforms_nonce'])), 'yayforms_preview_action')) {
             return 'Error: Security check failed.';
@@ -211,8 +210,10 @@ function yayforms_shortcode($atts) {
     wp_enqueue_script('yayforms-embed');
     
     // Para Elementor preview, adicionar o script diretamente no HTML
-    if (is_admin() || (isset($_GET['elementor-preview']) || isset($_GET['action']) && $_GET['action'] === 'elementor')) {
-        $embed_code .= '<script src="//embed.yayforms.link/next/embed.js"></script>';
+    $is_elementor_preview = isset($_GET['elementor-preview'])
+        || (isset($_GET['action']) && sanitize_text_field(wp_unslash($_GET['action'])) === 'elementor');
+    if (is_admin() || $is_elementor_preview) {
+        $embed_code .= '<script src="https://embed.yayforms.link/next/embed.js"></script>';
     }
     
     return $embed_code;

--- a/yayforms.php
+++ b/yayforms.php
@@ -208,12 +208,13 @@ function yayforms_shortcode($atts) {
         wp_register_script('yayforms-embed', '//embed.yayforms.link/next/embed.js', array(), '1.3', true);
     }
     wp_enqueue_script('yayforms-embed');
-    
-    // For Elementor preview, inject the script tag inline
-    $is_elementor_preview = isset($_GET['elementor-preview'])
-        || (isset($_GET['action']) && sanitize_text_field(wp_unslash($_GET['action'])) === 'elementor');
-    if (is_admin() || $is_elementor_preview) {
-        $embed_code .= '<script src="https://embed.yayforms.link/next/embed.js"></script>';
+
+    // In admin/AJAX contexts (e.g. page builder previews) wp_footer may not run,
+    // so print the registered script inline as a fallback.
+    if (is_admin() || wp_doing_ajax()) {
+        ob_start();
+        wp_print_scripts('yayforms-embed');
+        $embed_code .= ob_get_clean();
     }
     
     return $embed_code;

--- a/yayforms.php
+++ b/yayforms.php
@@ -104,9 +104,9 @@ function yayforms_shortcode($atts) {
         'color' => '#000000',
     ), $atts);
 
-    // Verificar nonce apenas se estiver na prévia do admin
-    if (wp_doing_ajax()) {
-        if (!isset($_REQUEST['yayforms_nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_REQUEST['yayforms_nonce'])), 'yayforms_preview_action')) {
+    // Verificar nonce apenas se estiver fazendo AJAX e tiver nonce disponível
+    if (wp_doing_ajax() && isset($_REQUEST['yayforms_nonce'])) {
+        if (!wp_verify_nonce(sanitize_text_field(wp_unslash($_REQUEST['yayforms_nonce'])), 'yayforms_preview_action')) {
             return 'Error: Security check failed.';
         }
     }

--- a/yayforms.php
+++ b/yayforms.php
@@ -33,6 +33,7 @@ function yayforms_enqueue_scripts() {
     wp_register_script('yayforms-embed', '//embed.yayforms.link/next/embed.js', array(), '1.3', true);
 }
 add_action('wp_enqueue_scripts', 'yayforms_enqueue_scripts');
+add_action('admin_enqueue_scripts', 'yayforms_enqueue_scripts');
 
 function yayforms_shortcode_generator() {
     ?>
@@ -203,7 +204,17 @@ function yayforms_shortcode($atts) {
             return '';
     }
 
+    // Garantir que o script seja carregado tanto no frontend quanto no admin
+    if (!wp_script_is('yayforms-embed', 'registered')) {
+        wp_register_script('yayforms-embed', '//embed.yayforms.link/next/embed.js', array(), '1.3', true);
+    }
     wp_enqueue_script('yayforms-embed');
+    
+    // Para Elementor preview, adicionar o script diretamente no HTML
+    if (is_admin() || (isset($_GET['elementor-preview']) || isset($_GET['action']) && $_GET['action'] === 'elementor')) {
+        $embed_code .= '<script src="//embed.yayforms.link/next/embed.js"></script>';
+    }
+    
     return $embed_code;
 }
 


### PR DESCRIPTION
## Summary
- Add parentheses to disambiguate `||`/`&&` in the Elementor preview detection (worked by precedence, but was ambiguous and WPCS-flagged).
- Sanitize and unslash `$_GET['action']` per WordPress coding standards.
- Use `https://` for the inline `<script>` fallback instead of protocol-relative `//`.
- Remove a stale Portuguese comment above the AJAX nonce check.

## Notes
- Did **not** touch the AJAX nonce check logic itself. The current "only validate if nonce present" pattern is still weak (nonce can be bypassed by omitting it), but the shortcode is render-only and the real CSRF-sensitive handler (`yayforms_preview_shortcode`) still validates the nonce strictly before calling `do_shortcode`. Flagging for follow-up rather than changing behavior in this hotfix.
- PR targets `hotfix/error-security` so it can be reviewed on top of the original hotfix before merging to `main`.

## Test plan
- [ ] Elementor preview renders the form embed (original bug this hotfix addresses).
- [ ] Shortcode renders correctly on a public page.
- [ ] Plugin check / WPCS no longer flags unsanitized `$_GET['action']`.